### PR TITLE
Input and output examples match described format

### DIFF
--- a/marsRover/readme.md
+++ b/marsRover/readme.md
@@ -34,15 +34,15 @@ The output for each rover should be its final co-ordinates and heading .
 
 _Test Input :_
 
-5 5
-1 2 N
-LMLMLMLMM
-3 3 E
+5 5  
+1 2 N  
+LMLMLMLMM  
+3 3 E  
 MMRMMRMRRM
 
 _Expected Output:_
 
-1 3 N
+1 3 N  
 5 1 E
 
 **_COMMAND LINE :_**


### PR DESCRIPTION
Input/output format is described as "lines" but example is displayed in one line.
Looking at the raw file the examples do follow the described format and data are spread over several lines.
This pull request fix the raw file in order for inputs and outputs to be displayed properly in a multi line format.